### PR TITLE
Tokenize \r as \n to use the same line splitting rules as BufferedReader

### DIFF
--- a/src/main/scala/com/futurice/testtoys/TestTokenizer.scala
+++ b/src/main/scala/com/futurice/testtoys/TestTokenizer.scala
@@ -44,8 +44,9 @@ class TestTokenizer(val reader: Reader) extends Iterator[String] {
             b.append(r.read.toChar)
           }
         }
-        else if (r.peek == '\n') {
-          b.append(r.read.toChar)
+        else if (r.peek == '\n' || r.peek == '\r') {
+          r.read
+          b.append('\n')
         }
         else if (Character.isDigit(r.peek)) {
           while (Character.isDigit(r.peek)) {


### PR DESCRIPTION
BufferedReade.readLine splits lines either at \n or \r. The tokenizer should use consistent logic, otherwise the parser will get out-of-sync when it encounters \r in the input.